### PR TITLE
Fix nameserver timeout error

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -271,7 +271,7 @@ if [ -z "${OFFLINE+x}" ]; then
     fi
 
     echo "Download Artifacts"
-    if ! aria2c --no-conf --log-level=info --log="$DOWNLOAD_DIR/aria2_download.log" -x16 -s16 -j5 -c -R -m0 --allow-overwrite=true --conditional-get=true -d"$DOWNLOAD_DIR" -i"$DOWNLOAD_DIR"/"$DOWNLOAD_CONF_NAME"; then
+    if ! aria2c --no-conf --log-level=info --log="$DOWNLOAD_DIR/aria2_download.log" -x16 -s16 -j5 -c -R -m0 --async-dns=false --allow-overwrite=true --conditional-get=true -d"$DOWNLOAD_DIR" -i"$DOWNLOAD_DIR"/"$DOWNLOAD_CONF_NAME"; then
         echo "We have encountered an error while downloading files."
         exit 1
     fi


### PR DESCRIPTION
During the step of downloading a file using Aria2c, a random download failure occurs due to a name server timeout.
I have looked into this issue and the download was successful with solution [here](https://github.com/aria2/aria2/issues/774).
I added `--async-dns=false` to the Aria2c options in build.sh for this purpose.