### PR TITLE
scripts: Fix MindTheGapps integration

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,7 +102,7 @@ usage(){
     --arch          Architecture of WSA, x64 or arm64, default: $ARCH
     --release-type  Release type of WSA, retail, RP (Release Preview), WIS (Insider Slow) or WIF (Insider Fast), default: $RELEASE_TYPE
     --magisk-ver    Magisk version, stable or canary, default: $MAGISK_VER
-    --gapps-brand   GApps brand, OpenGApps or MindTheGApps, default: $GAPPS_BRAND
+    --gapps-brand   GApps brand, OpenGApps or MindTheGapps, default: $GAPPS_BRAND
     --gapps-variant GApps variant, pico or full, etc...., default: $GAPPS_VARIANT
     --root-sol      Root solution, magisk or none, default: $ROOT_SOL
     --remove-amazon Remove Amazon Appstore from the system, default: false
@@ -183,7 +183,7 @@ MAGISK_VER_MAP=(
 
 GAPPS_BRAND_MAP=(
     "OpenGApps"
-    "MindTheGApps"
+    "MindTheGapps"
     "none"
 )
 
@@ -198,6 +198,7 @@ GAPPS_VARIANT_MAP=(
     "tvstock"
     "tvmini"
     "none"
+    "MindTheGapps"
 )
 
 ROOT_SOL_MAP=(
@@ -381,6 +382,9 @@ if [ -d "$WORK_DIR"/gapps ]; then
     SYSTEM_SIZE=$(( SYSTEM_SIZE + $(du --apparent-size -sB512 "$WORK_DIR"/gapps | cut -f1) - $(du --apparent-size -sB512 "$WORK_DIR"/gapps/product | cut -f1) ))
     if [ -d "$WORK_DIR"/gapps/system_ext ]; then
         SYSTEM_SIZE=$(( SYSTEM_SIZE - $(du --apparent-size -sB512 "$WORK_DIR"/gapps/system_ext | cut -f1) ))
+    fi
+    if [ -d "$WORK_DIR"/gapps/product ]; then
+        PRODUCT_SIZE=$(( PRODUCT_SIZE - $(du --apparent-size -sB512 "$WORK_DIR"/gapps/product | cut -f1) ))
     fi
 fi
 if [ -d "$WORK_DIR"/magisk ]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,6 +21,8 @@
 # DEBUG=--debug
 # CUSTOM_MAGISK=--magisk-custom
 
+DOWNLOAD_DIR=../download
+
 if [ ! "$BASH_VERSION" ] ; then
     echo "Please do not use sh to run this script, just execute it directly" 1>&2
     exit 1


### PR DESCRIPTION
* Fix MindTheGapps integration failure in build.sh due to missing element in GAPPS_BRAND_MAP and GAPPS_VARIANT_MAP
* Change MindTheGApps to MindTheGapps as that is the official name of the project[1]
* Add PRODUCT_SIZE caculation as MindTheGapps has gapps blobs and packages in product partion too

ref:
[1] https://gitlab.com/MindTheGapps/vendor_gapps

test:
Build, Boot, Applications work suceeds with custom built MindTheGapps x64 package.
(Google account singing still failed due to webview crash. Need to fixed in MS' side)
https://github.com/someone5678/MagiskOnWSALocal/releases/tag/12L-20220903

note:
You need to remove and re-install if you previously install WSA with OpenGApps integrated
as Application packages located on product partition in MindTheGapps not like OpenGApps (located in System partition).