### PR TITLE
Disable certificate check

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -322,7 +322,7 @@ if [ -z "${OFFLINE+x}" ]; then
     fi
 
     echo "Download Artifacts"
-    if ! aria2c --no-conf --log-level=info --log="$DOWNLOAD_DIR/aria2_download.log" -x16 -s16 -j5 -c -R -m0 --async-dns=false --check-integrity=true --continue=true --allow-overwrite=true --conditional-get=true -d"$DOWNLOAD_DIR" -i"$DOWNLOAD_DIR"/"$DOWNLOAD_CONF_NAME"; then
+    if ! aria2c --no-conf --log-level=info --log="$DOWNLOAD_DIR/aria2_download.log" -x16 -s16 -j5 -c -R -m0 --async-dns=false --check-integrity=true --continue=true --allow-overwrite=true --conditional-get=true --check-certificate=false -d"$DOWNLOAD_DIR" -i"$DOWNLOAD_DIR"/"$DOWNLOAD_CONF_NAME"; then
         echo "We have encountered an error while downloading files."
         exit 1
     fi


### PR DESCRIPTION
Fixed ssl certificate error when downloading gapps from sourceforge
```
[ERROR] [AbstractCommand.cc:349] CUID#11 - Download aborted. URI=https://downloads.sourceforge.net/project/wsa-mtg/x86_64/20220910/MindTheGapps-12.1.0-x86_64-20220910_001624.zip
Exception: [AbstractCommand.cc:351] errorCode=1 URI=https://downloads.sourceforge.net/project/wsa-mtg/x86_64/20220910/MindTheGapps-12.1.0-x86_64-20220910_001624.zip
  -> [SocketCore.cc:1018] errorCode=1 SSL/TLS handshake failure:  `not signed by known authorities or invalid' `expired'
```

Checklist
- [x] Have tested the modifications
