### PR TITLE
Fixed typo related to f.close()

### DIFF
--- a/scripts/generateGappsLink.py
+++ b/scripts/generateGappsLink.py
@@ -67,4 +67,3 @@ with open(download_dir/tempScript, 'a') as f:
         f.writelines(f'  out={brand}-{arch}-{variant}.zip\n')
     elif brand == "MindTheGapps":
         f.writelines(f'  out={brand}-{arch}.zip\n')
-    f.close

--- a/scripts/generateWSALinks.py
+++ b/scripts/generateWSALinks.py
@@ -112,4 +112,4 @@ for i, v, f in identities:
 tmpdownlist.writelines(f'https://aka.ms/Microsoft.VCLibs.{arch}.14.00.Desktop.appx\n')
 tmpdownlist.writelines(f'  dir={download_dir}\n')
 tmpdownlist.writelines(f'  out=vclibs-{arch}.appx\n')
-tmpdownlist.close
+tmpdownlist.close()


### PR DESCRIPTION
Fixed minor typo related to f.close().
Since `with` statement automatically calls close method, `f.close` on `generateGappsLink.py` is not needed. And `close` should be `close()` on `generateWSALinks.py`.