### PR TITLE
Fix output messages

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -22,6 +22,6 @@ jobs:
       id: check
       uses: ludeeus/action-shellcheck@master
       env:
-        SHELLCHECK_OPTS: -e SC2086 -e SC2260
+        SHELLCHECK_OPTS: -e SC2086
       with:
        scandir: './scripts'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -22,6 +22,6 @@ jobs:
       id: check
       uses: ludeeus/action-shellcheck@master
       env:
-        SHELLCHECK_OPTS: -e SC2086
+        SHELLCHECK_OPTS: -e SC2086 -e SC2260
       with:
        scandir: './scripts'

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
 
     Note that there is no x86_64 pre-build, so you need to build it by yourself ([Repository](https://gitlab.com/MindTheGapps/vendor_gapps)).
 
-    Or you can download the built package for 12.1-x86_64 from [this page](https://sourceforge.net/projects/wsa-mtg/files/x86_64/).
+    Or you can download the built package for 12.1 and 13 for x86_64 from [this page](https://sourceforge.net/projects/wsa-mtg/files/x86_64/).
 - Can I switch OpenGApps to MindTheGapps and keep user data in a previous build?
 
     No. You should wipe data after changing the GApps brand. Otherwise, you will find that the installed GApps are not recognized.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -536,9 +536,9 @@ echo -e "done\n"
 
 if [ "$REMOVE_AMAZON" ]; then
     echo "Remove Amazon Appstore"
-    # shellcheck disable=SC2260
+    # shellcheck disable=SC2210
     find "${MOUNT_DIR:?}"/product/{etc/permissions,etc/sysconfig,framework,priv-app} 2$>1 | grep -e amazon -e venezia | $SUDO xargs rm -rf
-    # shellcheck disable=SC2260
+    # shellcheck disable=SC2210
     find "${MOUNT_DIR:?}"/system_ext/{etc/*permissions,framework,priv-app} 2&>1 | grep -e amazon -e venezia | $SUDO xargs rm -rf
     echo -e "done\n"
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -536,7 +536,9 @@ echo -e "done\n"
 
 if [ "$REMOVE_AMAZON" ]; then
     echo "Remove Amazon Appstore"
+    # shellcheck disable=SC2260
     find "${MOUNT_DIR:?}"/product/{etc/permissions,etc/sysconfig,framework,priv-app} 2$>1 | grep -e amazon -e venezia | $SUDO xargs rm -rf
+    # shellcheck disable=SC2260
     find "${MOUNT_DIR:?}"/system_ext/{etc/*permissions,framework,priv-app} 2&>1 | grep -e amazon -e venezia | $SUDO xargs rm -rf
     echo -e "done\n"
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -536,10 +536,8 @@ echo -e "done\n"
 
 if [ "$REMOVE_AMAZON" ]; then
     echo "Remove Amazon Appstore"
-    # shellcheck disable=SC2210
-    find "${MOUNT_DIR:?}"/product/{etc/permissions,etc/sysconfig,framework,priv-app} 2$>1 | grep -e amazon -e venezia | $SUDO xargs rm -rf
-    # shellcheck disable=SC2210
-    find "${MOUNT_DIR:?}"/system_ext/{etc/*permissions,framework,priv-app} 2&>1 | grep -e amazon -e venezia | $SUDO xargs rm -rf
+    find "${MOUNT_DIR:?}"/product/{etc/permissions,etc/sysconfig,framework,priv-app} 2>/dev/null | grep -e amazon -e venezia | $SUDO xargs rm -rf
+    find "${MOUNT_DIR:?}"/system_ext/{etc/*permissions,framework,priv-app} 2>/dev/null | grep -e amazon -e venezia | $SUDO xargs rm -rf
     echo -e "done\n"
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -536,8 +536,8 @@ echo -e "done\n"
 
 if [ "$REMOVE_AMAZON" ]; then
     echo "Remove Amazon Appstore"
-    find "${MOUNT_DIR:?}"/product/{etc/permissions,etc/sysconfig,framework,priv-app} | grep -e amazon -e venezia | $SUDO xargs rm -rf
-    find "${MOUNT_DIR:?}"/system_ext/{etc/*permissions,framework,priv-app} | grep -e amazon -e venezia | $SUDO xargs rm -rf
+    find "${MOUNT_DIR:?}"/product/{etc/permissions,etc/sysconfig,framework,priv-app} 2$>1 | grep -e amazon -e venezia | $SUDO xargs rm -rf
+    find "${MOUNT_DIR:?}"/system_ext/{etc/*permissions,framework,priv-app} 2&>1 | grep -e amazon -e venezia | $SUDO xargs rm -rf
     echo -e "done\n"
 fi
 


### PR DESCRIPTION
Checklist

- [x] Have tested the modifications
---

<details><summary>Build Log:</summary>

```
s1204@TUF:~/MagiskOnWSALocal$ ./scripts/build.sh --arch x64 --release-type WIF --skip-download-wsa --magisk-ver canary --gapps-brand MindTheGapps --gapps-variant pico --remove-amazon --root-sol magisk --nofix-props --compress-format 7z
INFO: Architecture: x64
INFO: Release Type: WIF
INFO: Magisk Version: canary
INFO: GApps Brand: MindTheGapps
INFO: GApps Variant: pico
INFO: Root Solution: magisk
INFO: Compress Format: 7z
Build: RELEASE_TYPE=Insider Fast
Generating Magisk download link: release type=canary
download link: https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@5b2934603f979d7133e67bbc30c6ce3fa0d8e31e/app-release.apk
Generating MindTheGapps download link: arch=x64 variant=pico
download link: https://downloads.sourceforge.net/project/wsa-mtg/x86_64/20221208/MindTheGapps-13.0.0-x86_64-20221208_045947.zip
Download Artifacts

01/05 19:09:08 [NOTICE] Downloading 2 item(s)

01/05 19:09:09 [NOTICE] GID#eb7136e1d161e7ea - Download has already completed: /home/s1204/MagiskOnWSALocal/download/magisk-canary.zip

01/05 19:09:09 [NOTICE] ダウンロード完了: /home/s1204/MagiskOnWSALocal/download/magisk-canary.zip

01/05 19:09:09 [NOTICE] CUID#8 - Redirecting to https://jaist.dl.sourceforge.net/project/wsa-mtg/x86_64/20221208/MindTheGapps-13.0.0-x86_64-20221208_045947.zip

01/05 19:09:09 [NOTICE] GID#ddfd55642a3e4b32 - Download has already completed: /home/s1204/MagiskOnWSALocal/download/MindTheGapps-x64-13.0.zip

01/05 19:09:09 [NOTICE] ダウンロード完了: /home/s1204/MagiskOnWSALocal/download/MindTheGapps-x64-13.0.zip

ダウンロード結果:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
eb7136|OK  |       0B/s|/home/s1204/MagiskOnWSALocal/download/magisk-canary.zip
ddfd55|OK  |       0B/s|/home/s1204/MagiskOnWSALocal/download/MindTheGapps-x64-13.0.zip

凡例:
(OK):ダウンロード完了しました
Extract WSA
unzipping to /tmp/wsa-build-nKoNx41YmI_/wsa
unzipping from /tmp/wsa-build-nKoNx41YmI_/wsa/WsaPackage_2211.40000.10.0_x64_Release-Nightly.msix
Extract done

Extract Magisk
Magisk version: 831a398b (25206)
done

Extract MindTheGapps
Archive:  ../download/MindTheGapps-x64-13.0.zip
signed by SignApk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/app/GoogleCalendarSyncAdapter/GoogleCalendarSyncAdapter.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/app/GoogleContactsSyncAdapter/GoogleContactsSyncAdapter.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/app/PrebuiltExchange3Google/PrebuiltExchange3Google.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/default-permissions/default-permissions-google.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/default-permissions/default-permissions-mtg.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/permissions/com.google.android.dialer.support.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/permissions/privapp-permissions-google-product.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/security/fsverity/gms_fsverity_cert.der
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/sysconfig/d2d_cable_migration_feature.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/sysconfig/google-hiddenapi-package-allowlist.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/sysconfig/google.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/etc/sysconfig/google_build.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/framework/com.google.android.dialer.support.jar
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/lib/libjni_latinimegoogle.so
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/lib64/libjni_latinimegoogle.so
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/overlay/GmsOverlay.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/overlay/GmsSettingsProviderOverlay.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/priv-app/AndroidAutoStub/AndroidAutoStub.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/priv-app/GmsCore/GmsCore.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/priv-app/GooglePartnerSetup/GooglePartnerSetup.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/priv-app/GoogleRestore/GoogleRestore.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/priv-app/Phonesky/Phonesky.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/product/priv-app/Velvet/Velvet.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/system_ext/etc/permissions/privapp-permissions-google-system-ext.xml
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/system_ext/priv-app/GoogleFeedback/GoogleFeedback.apk
  inflating: /tmp/wsa-build-nKoNx41YmI_/gapps/system/system_ext/priv-app/GoogleServicesFramework/GoogleServicesFramework.apk
Extract done

Expand images
system_ext: 99/128 files (1.0% non-contiguous), 44589/44723 blocks
resize2fs 1.45.5 (07-Jan-2020)
Resizing the filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/system_ext.img to 50013 (4k) blocks.
The filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/system_ext.img is now 50013 (4k) blocks long.

product: 132/144 files (0.0% non-contiguous), 74672/74897 blocks
resize2fs 1.45.5 (07-Jan-2020)
Resizing the filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/product.img to 191715 (4k) blocks.
The filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/product.img is now 191715 (4k) blocks long.

/: 2762/2816 files (0.4% non-contiguous), 224508/239777 blocks
resize2fs 1.45.5 (07-Jan-2020)
Resizing the filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/system.img to 250131 (4k) blocks.
The filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/system.img is now 250131 (4k) blocks long.

vendor: 1103/1120 files (0.5% non-contiguous), 61069/61260 blocks
resize2fs 1.45.5 (07-Jan-2020)
Resizing the filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/vendor.img to 64964 (4k) blocks.
The filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/vendor.img is now 64964 (4k) blocks long.

Expand images done

Mount images
mount: /dev/loop0 は /tmp/wsa-build-nKoNx41YmI_/system にマウントされました。
mount: /dev/loop1 は /tmp/wsa-build-nKoNx41YmI_/system/vendor にマウントされました。
mount: /dev/loop2 は /tmp/wsa-build-nKoNx41YmI_/system/product にマウントされました。
mount: /dev/loop3 は /tmp/wsa-build-nKoNx41YmI_/system/system_ext にマウントされました。
done

Remove Amazon Appstore
done

Add device administration features
done

Integrate Magisk
/dev/zahhjbje(/.*)?    u:object_r:magisk_file:s0
/data/adb/magisk(/.*)?   u:object_r:magisk_file:s0
Integrate Magisk done

Merge Language Resources
Index Pass Completed.
AlternateForm Qualifiers: LIGHTUNPLATED,UNPLATED
Language Qualifiers: EN-US,EN-GB,AF-ZA,AR-SA,AZ-LATN-AZ,BG-BG,BS-LATN-BA,CA-ES,CS-CZ,CY-GB,DA-DK,DE-DE,EL-GR,ES-ES,ES-MX,ET-EE,EU-ES,FA-IR,FI-FI,FR-CA,FR-FR,GL-ES,HE-IL,HI-IN,HR-HR,HU-HU,ID-ID,IS-IS,IT-IT,JA-JP,KA-GE,KK-KZ,KO-KR,LT-LT,LV-LV,MS-MY,NB-NO,NL-NL,NN-NO,PL-PL,PT-BR,PT-PT,QPS-PLOC,QPS-PLOCA,QPS-PLOCM,RO-RO,RU-RU,SL-SI,SQ-AL,SR-CYRL-RS,SR-LATN-RS,SV-SE,TH-TH,TR-TR,UK-UA,VI-VN,ZH-CN,ZH-TW
Scale Qualifiers: 200,400,150,125,100
TargetSize Qualifiers: 256,16,20,24,30,32,36,40,48,60,64,72,80,96

Finished building
Version: 1.0
Resource Map Name: MicrosoftCorporationII.WindowsSubsystemForAndroid
Named Resources: 289
Resource Candidates: 12699
Successfully Completed
Merge Language Resources done

Add extra packages
Add extra packages done

Integrate MindTheGapps
Integrate MindTheGapps done

Skip fix MindTheGapps prop!
WARNING: Services such as the Play Store may stop working properly.
We are not responsible for any problems caused by this!
Info: https://support.google.com/android/answer/10248227

Umount images
umount: /tmp/wsa-build-nKoNx41YmI_/system/vendor をアンマウントしました
umount: /tmp/wsa-build-nKoNx41YmI_/system/product をアンマウントしました
umount: /tmp/wsa-build-nKoNx41YmI_/system/system_ext をアンマウントしました
umount: /tmp/wsa-build-nKoNx41YmI_/system をアンマウントしました
done

Shrink images
/: 2775/2816 files (0.4% non-contiguous), 228430/250131 blocks
resize2fs 1.45.5 (07-Jan-2020)
Resizing the filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/system.img to 229493 (4k) blocks.
The filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/system.img is now 229493 (4k) blocks long.

vendor: 1103/1120 files (0.5% non-contiguous), 61134/64964 blocks
resize2fs 1.45.5 (07-Jan-2020)
Resizing the filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/vendor.img to 61141 (4k) blocks.
The filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/vendor.img is now 61141 (4k) blocks long.

product: 170/288 files (1.8% non-contiguous), 187626/191715 blocks
resize2fs 1.45.5 (07-Jan-2020)
Resizing the filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/product.img to 187634 (4k) blocks.
The filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/product.img is now 187634 (4k) blocks long.

system_ext: 104/128 files (1.0% non-contiguous), 46532/50013 blocks
resize2fs 1.45.5 (07-Jan-2020)
Resizing the filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/system_ext.img to 46538 (4k) blocks.
The filesystem on /tmp/wsa-build-nKoNx41YmI_/wsa/x64/system_ext.img is now 46538 (4k) blocks long.

Shrink images done

Remove signature and add scripts
Remove signature and add scripts done

Generate info
WSA_2211.40000.10.0_x64_Release-Nightly-with-magisk-831a398b(25206)-canary-MindTheGapps-13.0-NoFixProps-RemovedAmazon

Finishing building....
Compressing with 7z

7-Zip [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
p7zip Version 16.02 (locale=ja_JP.UTF8,Utf16=on,HugeFiles=on,64 bits,8 CPUs 12th Gen Intel(R) Core(TM) i3-12100 (90675),ASM,AES-NI)

Scanning the drive:
31 folders, 163 files, 2281744246 bytes (2177 MiB)

Creating archive: ../output/WSA_2211.40000.10.0_x64_Release-Nightly-with-magisk-831a398b(25206)-canary-MindTheGapps-13.0-NoFixProps-RemovedAmazon.7z

Items to compress: 194


Files read from disk: 163
Archive size: 739323766 bytes (706 MiB)
Everything is Ok
done

Cleanup Work Directory
done
```
</details>