### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@
 
   | DistrOS             |                                                                           |            |            |              |
   |:-------------------:|---------------------------------------------------------------------------|------------|------------|--------------|
-  | Debian              | `lzip patchelf e2fsprogs python3 python3-pip aria2 p7zip-full attr unzip` | `whiptail` | `xz-utils` | `qemu-utils` |
+  | Debian              | `lzip patchelf e2fsprogs python3 python3-pip aria2 p7zip-full attr unzip qemu-utils` | `whiptail` | `xz-utils` | `qemu-utils` |
   | openSUSE Tumbleweed | Same as above                                                             | `dialog`   | `xz`       | `qemu-tools` |
 
   The python3 library `requests` is used.


### PR DESCRIPTION
fix "./build.sh: line 135: qemu-img: command not found"

```
Extract done

Calculate the required space
done

Expand images
Convert vhdx to img and remove read-only flag
./build.sh: line 135: qemu-img: command not found
Build: an error has occurred, exit
```

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.

  DELETE THIS SECTION IF YOU HAVE READ AND ACKNOWLEDGED IT.
-->

Checklist

- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications
