### PR TITLE
Update install_deps.sh

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -43,7 +43,7 @@ check_dependencies() {
     command -v patchelf >/dev/null 2>&1 || NEED_INSTALL+=("patchelf")
     command -v resize2fs >/dev/null 2>&1 || NEED_INSTALL+=("e2fsprogs")
     command -v pip >/dev/null 2>&1 || NEED_INSTALL+=("python3-pip")
-    command -v aria2c >/dev/null 2>&1 || NEED_INSTALL+=("aria2")
+    command -v aria2c >/dev/null 2>&1 || NEED_INSTALL+=("aria2 ca-certificates")
     command -v 7z > /dev/null 2>&1 || NEED_INSTALL+=("p7zip-full")
     command -v setfattr > /dev/null 2>&1 || NEED_INSTALL+=("attr")
     command -v xz > /dev/null 2>&1 || NEED_INSTALL+=("xz-utils")


### PR DESCRIPTION
added ca-certificates to aria2, because for some reason certificate is invalid when building.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.

  DELETE THIS SECTION IF YOU HAVE READ AND ACKNOWLEDGED IT.
-->

Checklist

- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications
