### PR TITLE
Add support for Gentoo

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -55,7 +55,7 @@ osrel=$(sed -n '/^ID_LIKE=/s/^.*=//p' /etc/os-release)
 declare -A os_pm_install
 # os_pm_install["/etc/redhat-release"]=yum
 os_pm_install["/etc/arch-release"]=pacman
-# os_pm_install["/etc/gentoo-release"]=emerge
+os_pm_install["/etc/gentoo-release"]=emerge
 os_pm_install["/etc/SuSE-release"]=zypper
 os_pm_install["/etc/debian_version"]=apt-get
 # os_pm_install["/etc/alpine-release"]=apk
@@ -63,7 +63,7 @@ os_pm_install["/etc/debian_version"]=apt-get
 declare -A PM_UPDATE_MAP
 PM_UPDATE_MAP["yum"]="check-update"
 PM_UPDATE_MAP["pacman"]="-Syu --noconfirm"
-PM_UPDATE_MAP["emerge"]="-auDN @world"
+PM_UPDATE_MAP["emerge"]="-auDU1 @world"
 PM_UPDATE_MAP["zypper"]="ref"
 PM_UPDATE_MAP["apt-get"]="update"
 PM_UPDATE_MAP["apk"]="update"
@@ -105,7 +105,8 @@ require_su
 if [ -z "$PM" ]; then
     echo "Unable to determine package manager: Unsupported distros"
     abort
-elif [ "$PM" = "pacman" ]; then
+elif [[ "$PM" =~ pacman|emerge ]]; then
+    [ "$PM" = "emerge" ] && (sudo emerge -qoO aria2[adns] || abort)
     i=30
     while ((i-- > 1)) &&
         ! read -r -sn 1 -t 1 -p $'\r:: Proceed with full system upgrade? Cancel after '$i$'s.. [y/N]\e[0K ' answer; do
@@ -147,6 +148,17 @@ if [ -n "${NEED_INSTALL[*]}" ]; then
             NEED_INSTALL_FIX=${NEED_INSTALL_FIX//qemu-utils/qemu-img} 2>&1
             NEED_INSTALL_FIX=${NEED_INSTALL_FIX//python3-pip/python-pip} 2>&1
             NEED_INSTALL_FIX=${NEED_INSTALL_FIX//p7zip-full/p7zip} 2>&1
+        } >>/dev/null
+
+        readarray -td ' ' NEED_INSTALL <<<"$NEED_INSTALL_FIX "
+        unset 'NEED_INSTALL[-1]'
+    elif [ "$PM" = "emerge" ]; then
+        NEED_INSTALL_FIX=${NEED_INSTALL[*]}
+        {
+            NEED_INSTALL_FIX=${NEED_INSTALL_FIX//whiptail/dialog} 2>&1
+            NEED_INSTALL_FIX=${NEED_INSTALL_FIX//python3-pip/dev-python/pip} 2>&1
+            NEED_INSTALL_FIX=${NEED_INSTALL_FIX//p7zip-full/p7zip} 2>&1
+            NEED_INSTALL_FIX=${NEED_INSTALL_FIX//qemu-utils/qemu} 2>&1
         } >>/dev/null
 
         readarray -td ' ' NEED_INSTALL <<<"$NEED_INSTALL_FIX "


### PR DESCRIPTION
Tested on a minimal Gentoo build in WSL. I reused the [Arch update code](https://github.com/LSPosed/MagiskOnWSALocal/commit/3d819b9ba52a0e05fdf9df3d980395b3b4f20daa#diff-c3ff4e129c54b291da6bdad23c8664c34a78325e7c02e8c13404041836bb82d6R110) to limit the number of additions, but I'm also happy to split this off into a separate `elif [ "$PM" = "emerge" ];` block instead. In terms of Gentoo specific challenges, `aria2[adns]` was the only required USE flag that wasn't enabled for me by default, but if more checks are needed they only need to be added [here](https://github.com/LSPosed/MagiskOnWSALocal/commit/e826d02f7690465b73fecc60583bc540fe5f016c#diff-c3ff4e129c54b291da6bdad23c8664c34a78325e7c02e8c13404041836bb82d6R109).

- Avoid unneeded rebuilds by using `-U` instead of `-D`
- Avoid adding ca-cetificates to @selected by using `-1`
- Ensure aria2 is built with the `adns` USE flag
- Use dialog instead of whiptail to limit dependencies


Checklist

- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications
