### PR TITLE
Download correct WSA version

### DIFF
--- a/scripts/generateWSALinks.py
+++ b/scripts/generateWSALinks.py
@@ -144,6 +144,13 @@ def send_req(i, v, out_file_name):
 threads = []
 wsa_build_ver = 0
 for filename, values in identities.items():
+    if re.match(f"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
+        tmp_wsa_build_ver = re.search(u'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
+        if(wsa_build_ver == 0):
+            wsa_build_ver = tmp_wsa_build_ver
+        elif version.parse(wsa_build_ver) < version.parse(tmp_wsa_build_ver):
+            wsa_build_ver = tmp_wsa_build_ver
+for filename, values in identities.items():
     if re.match(f"Microsoft\.UI\.Xaml\..*_{arch}_.*\.appx", filename):
         out_file_name = f"{values[1]}_{arch}.appx"
         out_file = download_dir / out_file_name
@@ -155,13 +162,8 @@ for filename, values in identities.items():
         out_file = download_dir / out_file_name
     elif re.match(f"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
         tmp_wsa_build_ver = re.search(u'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
-        if(wsa_build_ver == 0):
-            wsa_build_ver = tmp_wsa_build_ver
-        else:
-            if version.parse(wsa_build_ver) < version.parse(tmp_wsa_build_ver):
-                wsa_build_ver = tmp_wsa_build_ver
-            else:
-                continue
+        if(wsa_build_ver != tmp_wsa_build_ver):
+            continue
         version_splited = wsa_build_ver.split(".")
         major_ver = version_splited[0]
         minor_ver = version_splited[1]


### PR DESCRIPTION
This fixes a bug in the script which created a race condition, since it searched download links for multiple versions and the last one finishing was the one used

- [X] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [X] Have tested the modifications
