### PR TITLE
Fedora support + remove build warnings

### DIFF
--- a/scripts/extractWSA.py
+++ b/scripts/extractWSA.py
@@ -104,7 +104,7 @@ with zipfile.ZipFile(wsa_zip_path) as zip:
                     elif g.filename == 'AppxManifest.xml':
                         g.filename = f'resources.{name}.xml'
                         l.extract(g, xmldir)
-                    elif re.search(u'Images/.+\.png', g.filename):
+                    elif re.search(r'Images/.+\.png', g.filename):
                         l.extract(g, archdir)
 with zipfile.ZipFile(zip_path) as zip:
     stat = Path(zip_path).stat()

--- a/scripts/generateGappsLink.py
+++ b/scripts/generateGappsLink.py
@@ -50,12 +50,12 @@ if brand == "OpenGApps":
         print("Failed to fetch from OpenGApps API, fallbacking to SourceForge RSS...")
         res = requests.get(
             f'https://sourceforge.net/projects/opengapps/rss?path=/{abi_map[arch]}&limit=100')
-        link = re.search(f'https://.*{abi_map[arch]}/.*{release}.*{variant}.*\.zip/download', res.text).group().replace(
+        link = re.search(fr'https://.*{abi_map[arch]}/.*{release}.*{variant}.*\.zip/download', res.text).group().replace(
             '.zip/download', '.zip').replace('sourceforge.net/projects/opengapps/files', 'downloads.sourceforge.net/project/opengapps')
 elif brand == "MindTheGapps":
     res = requests.get(
         f'https://sourceforge.net/projects/wsa-mtg/rss?path=/{abi_map[arch]}&limit=100')
-    matched = re.search(f'https://.*{release}.*{abi_map[arch]}.*\.zip/download', res.text)
+    matched = re.search(fr'https://.*{release}.*{abi_map[arch]}.*\.zip/download', res.text)
     if matched:
         link = matched.group().replace(
             '.zip/download', '.zip').replace('sourceforge.net/projects/wsa-mtg/files', 'downloads.sourceforge.net/project/wsa-mtg')
@@ -68,7 +68,7 @@ elif brand == "MindTheGapps":
         if res.status_code == 200:
             assets = json_data["assets"]
             for asset in assets:
-                if re.match(f'.*{release}.*{abi_map[arch]}.*\.zip$', asset["name"]) and asset["content_type"] == "application/zip":
+                if re.match(fr'.*{release}.*{abi_map[arch]}.*\.zip$', asset["name"]) and asset["content_type"] == "application/zip":
                     link = asset["browser_download_url"]
                     break
         elif res.status_code == 403 and x_ratelimit_remaining == '0':

--- a/scripts/generateKernelSULink.py
+++ b/scripts/generateKernelSULink.py
@@ -62,7 +62,7 @@ if res.status_code == 200:
     link = ""
     assets = json_data["assets"]
     for asset in assets:
-        if re.match(f'kernel-WSA-{abi_map[arch]}-{kernelVersion}.*\.zip$', asset["name"]) and asset["content_type"] == "application/zip":
+        if re.match(fr'kernel-WSA-{abi_map[arch]}-{kernelVersion}.*\.zip$', asset["name"]) and asset["content_type"] == "application/zip":
             link = asset["browser_download_url"]
             break
     if link == "":

--- a/scripts/generateWSALinks.py
+++ b/scripts/generateWSALinks.py
@@ -145,24 +145,24 @@ def send_req(i, v, out_file_name):
 threads = []
 wsa_build_ver = 0
 for filename, values in identities.items():
-    if re.match(f"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
-        tmp_wsa_build_ver = re.search(u'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
+    if re.match(fr"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
+        tmp_wsa_build_ver = re.search(r'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
         if(wsa_build_ver == 0):
             wsa_build_ver = tmp_wsa_build_ver
         elif version.parse(wsa_build_ver) < version.parse(tmp_wsa_build_ver):
             wsa_build_ver = tmp_wsa_build_ver
 for filename, values in identities.items():
-    if re.match(f"Microsoft\.UI\.Xaml\..*_{arch}_.*\.appx", filename):
+    if re.match(fr"rMicrosoft\.UI\.Xaml\..*_{arch}_.*\.appx", filename):
         out_file_name = f"{values[1]}_{arch}.appx"
         out_file = download_dir / out_file_name
-    elif re.match(f"Microsoft\.VCLibs\..+\.UWPDesktop_.*_{arch}_.*\.appx", filename):
+    elif re.match(fr"Microsoft\.VCLibs\..+\.UWPDesktop_.*_{arch}_.*\.appx", filename):
         out_file_name = f"{values[1]}_{arch}.appx"
         out_file = download_dir / out_file_name
-    elif re.match(f"Microsoft\.VCLibs\..+_.*_{arch}_.*\.appx", filename):
+    elif re.match(fr"Microsoft\.VCLibs\..+_.*_{arch}_.*\.appx", filename):
         out_file_name = f"{values[1]}_{arch}.appx"
         out_file = download_dir / out_file_name
-    elif not skip_wsa_download and re.match(f"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
-        tmp_wsa_build_ver = re.search(u'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
+    elif not skip_wsa_download and re.match(fr"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
+        tmp_wsa_build_ver = re.search(r'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
         if(wsa_build_ver != tmp_wsa_build_ver):
             continue
         version_splitted = wsa_build_ver.split(".")


### PR DESCRIPTION
Add support for _**Fedora 39**_ (tested under `WSL`).

Use raw literal in python regex strings, this is the right way to escape regex's special characters in python.
Otherwise, python first tries to escape the characters itself, fails and issue a warning which is confusing to user.

Checklist
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications
