### PR TITLE
install_deps: upgrade only specified packages, not full system

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -77,8 +77,12 @@ PM_INSTALL_MAP["apt-get"]="install -y"
 PM_INSTALL_MAP["apk"]="add"
 
 declare -A PM_UPGRADE_MAP
-PM_UPGRADE_MAP["apt-get"]="upgrade -y"
+PM_UPGRADE_MAP["apt-get"]="install -y"
 PM_UPGRADE_MAP["zypper"]="up -y"
+
+declare -A PM_SYSTEM_UPGRADE_MAP
+PM_SYSTEM_UPGRADE_MAP["apt-get"]="upgrade"
+PM_SYSTEM_UPGRADE_MAP["zypper"]="up"
 
 check_package_manager() {
     for f in "${!os_pm_install[@]}"; do
@@ -97,6 +101,8 @@ check_package_manager() {
         unset 'INSTALL_OPTION[-1]'
         readarray -td ' ' UPGRADE_OPTION <<<"${PM_UPGRADE_MAP[$PM]} "
         unset 'UPGRADE_OPTION[-1]'
+        readarray -td ' ' SYSTEM_UPGRADE_OPTION <<<"${PM_SYSTEM_UPGRADE_MAP[$PM]} "
+        unset 'SYSTEM_UPGRADE_OPTION[-1]'
     fi
 }
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -83,10 +83,6 @@ declare -A PM_UPGRADE_MAP
 PM_UPGRADE_MAP["apt-get"]="install -y"
 PM_UPGRADE_MAP["zypper"]="up -y"
 
-declare -A PM_SYSTEM_UPGRADE_MAP
-PM_SYSTEM_UPGRADE_MAP["apt-get"]="upgrade"
-PM_SYSTEM_UPGRADE_MAP["zypper"]="up"
-
 check_package_manager() {
     for f in "${!os_pm_install[@]}"; do
         if [[ -f $f ]]; then
@@ -104,8 +100,6 @@ check_package_manager() {
         unset 'INSTALL_OPTION[-1]'
         readarray -td ' ' UPGRADE_OPTION <<<"${PM_UPGRADE_MAP[$PM]} "
         unset 'UPGRADE_OPTION[-1]'
-        readarray -td ' ' SYSTEM_UPGRADE_OPTION <<<"${PM_SYSTEM_UPGRADE_MAP[$PM]} "
-        unset 'SYSTEM_UPGRADE_OPTION[-1]'
     fi
 }
 


### PR DESCRIPTION
Change `install_deps.sh` script behaviour especially for Debian-based systems to only upgrade specified packages instead of all installed packages. (e.g. `apt-get install -y ca-certificates` instead of `apt-get upgrade -y ca-certificates` where `ca-certificates` is ignored and a full system upgrade is launched)

A full system upgrade is not necessary because the package manager handle dependencies/libraries upgrade automatically when you install/upgrade packages.

A full system upgrade can even be dangerous/unwanted on some cases, especially because of the `-y` option used here (e.g. a pending display driver update that could break everything with the next reboot).

However, if ever in the future there is a real need for a complete system upgrade, the upgrade commands have been moved to a new `PM_SYSTEM_UPGRADE_MAP` array (with its related `SYSTEM_UPGRADE_OPTION`), this time without the `-y` argument to let the user check and confirm the proposed updates.

Checklist

- [x] Have tested the modifications
-> Yes, on a Debian-based system (Ubuntu 23.10). Suse should not be impacted as the command is the same whether to update a package (`zypper up <package>`) or all packages (`zypper up`)