### PR TITLE
Fix python `SyntaxWarning`s on non-raw regex strings

### DIFF
--- a/scripts/extractWSA.py
+++ b/scripts/extractWSA.py
@@ -108,5 +108,5 @@ with zipfile.ZipFile(wsa_zip_path) as zip:
                     elif g.filename == 'AppxManifest.xml':
                         g.filename = f'resources.{name}.xml'
                         l.extract(g, xmldir)
-                    elif re.search(u'Images/.+\.png', g.filename):
+                    elif re.search(r'Images/.+\.png', g.filename):
                         l.extract(g, archdir)

--- a/scripts/generateGappsLink.py
+++ b/scripts/generateGappsLink.py
@@ -59,9 +59,9 @@ if res.status_code == 200:
     download_files = {}
     assets = json_data["assets"]
     for asset in assets:
-        if re.match(f'gapps.*{release}.*\.rc$', asset["name"]):
+        if re.match(rf'gapps.*{release}.*\.rc$', asset["name"]):
             download_files[asset["name"]] = asset["browser_download_url"]
-        elif re.match(f'gapps.*{release}.*{abi_map[arch]}.*\.img$', asset["name"]):
+        elif re.match(rf'gapps.*{release}.*{abi_map[arch]}.*\.img$', asset["name"]):
             download_files[asset["name"]] = asset["browser_download_url"]
     with open(download_dir/tempScript, 'a') as f:
         for key, value in download_files.items():

--- a/scripts/generateKernelSULink.py
+++ b/scripts/generateKernelSULink.py
@@ -67,7 +67,7 @@ if res.status_code == 200:
     assets = json_data["assets"]
     for asset in assets:
         asset_name = asset["name"]
-        if re.match(f'kernel-WSA-{abi_map[arch]}-{kernelVersion}.*\.zip$', asset_name) and asset["content_type"] == "application/zip":
+        if re.match(rf'kernel-WSA-{abi_map[arch]}-{kernelVersion}.*\.zip$', asset_name) and asset["content_type"] == "application/zip":
             tmp_kernel_ver = re.search(
                 u'\d{1}.\d{1,}.\d{1,}.\d{1,}', asset_name.split("-")[3]).group()
             if (kernel_ver == 0):
@@ -76,7 +76,7 @@ if res.status_code == 200:
                 kernel_ver = tmp_kernel_ver
     print(f"Kernel version: {kernel_ver}", flush=True)
     for asset in assets:
-        if re.match(f'kernel-WSA-{abi_map[arch]}-{kernel_ver}.*\.zip$', asset["name"]) and asset["content_type"] == "application/zip":
+        if re.match(rf'kernel-WSA-{abi_map[arch]}-{kernel_ver}.*\.zip$', asset["name"]) and asset["content_type"] == "application/zip":
             link = asset["browser_download_url"]
             break
     if link == "":

--- a/scripts/generateWSALinks.py
+++ b/scripts/generateWSALinks.py
@@ -145,26 +145,26 @@ def send_req(i, v, out_file_name):
 threads = []
 wsa_build_ver = 0
 for filename, values in identities.items():
-    if re.match(f"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
+    if re.match(rf"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
         tmp_wsa_build_ver = re.search(
-            u'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
+            r'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
         if (wsa_build_ver == 0):
             wsa_build_ver = tmp_wsa_build_ver
         elif version.parse(wsa_build_ver) < version.parse(tmp_wsa_build_ver):
             wsa_build_ver = tmp_wsa_build_ver
 for filename, values in identities.items():
-    if re.match(f"Microsoft\.UI\.Xaml\..*_{arch}_.*\.appx", filename):
+    if re.match(rf"Microsoft\.UI\.Xaml\..*_{arch}_.*\.appx", filename):
         out_file_name = f"{values[1]}_{arch}.appx"
         out_file = download_dir / out_file_name
-    elif re.match(f"Microsoft\.VCLibs\..+\.UWPDesktop_.*_{arch}_.*\.appx", filename):
+    elif re.match(rf"Microsoft\.VCLibs\..+\.UWPDesktop_.*_{arch}_.*\.appx", filename):
         out_file_name = f"{values[1]}_{arch}.appx"
         out_file = download_dir / out_file_name
-    elif re.match(f"Microsoft\.VCLibs\..+_.*_{arch}_.*\.appx", filename):
+    elif re.match(rf"Microsoft\.VCLibs\..+_.*_{arch}_.*\.appx", filename):
         out_file_name = f"{values[1]}_{arch}.appx"
         out_file = download_dir / out_file_name
-    elif not skip_wsa_download and re.match(f"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
+    elif not skip_wsa_download and re.match(rf"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
         tmp_wsa_build_ver = re.search(
-            u'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
+            r'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
         if (wsa_build_ver != tmp_wsa_build_ver):
             continue
         version_splitted = wsa_build_ver.split(".")


### PR DESCRIPTION
This fixes some `SyntaxWarning`s from new(er) python versions on non-raw strings used in `re.` contexts.

```sh
$ python3 --version
3.12.4
```

e.g.
```
COMMAND_LINE=--arch x64 --release-type retail --root-sol magisk --magisk-ver stable --install-gapps --remove-amazon
INFO: Architecture: x64
INFO: Release Type: retail
INFO: Magisk Version: stable
INFO: Root Solution: magisk
INFO: Compress Format: none
INFO: Release Name: Retail

Generating WSA Download Links
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:148: SyntaxWarning: invalid escape sequence '\.'
  if re.match(f"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:150: SyntaxWarning: invalid escape sequence '\d'
  u'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:156: SyntaxWarning: invalid escape sequence '\.'
  if re.match(f"Microsoft\.UI\.Xaml\..*_{arch}_.*\.appx", filename):
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:156: SyntaxWarning: invalid escape sequence '\.'
  if re.match(f"Microsoft\.UI\.Xaml\..*_{arch}_.*\.appx", filename):
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:159: SyntaxWarning: invalid escape sequence '\.'
  elif re.match(f"Microsoft\.VCLibs\..+\.UWPDesktop_.*_{arch}_.*\.appx", filename):
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:159: SyntaxWarning: invalid escape sequence '\.'
  elif re.match(f"Microsoft\.VCLibs\..+\.UWPDesktop_.*_{arch}_.*\.appx", filename):
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:162: SyntaxWarning: invalid escape sequence '\.'
  elif re.match(f"Microsoft\.VCLibs\..+_.*_{arch}_.*\.appx", filename):
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:162: SyntaxWarning: invalid escape sequence '\.'
  elif re.match(f"Microsoft\.VCLibs\..+_.*_{arch}_.*\.appx", filename):
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:165: SyntaxWarning: invalid escape sequence '\.'
  elif not skip_wsa_download and re.match(f"MicrosoftCorporationII\.WindowsSubsystemForAndroid_.*\.msixbundle", filename):
/mnt/d/GitHub/MagiskOnWSALocal/scripts/generateWSALinks.py:167: SyntaxWarning: invalid escape sequence '\d'
  u'\d{4}.\d{5}.\d{1,}.\d{1,}', filename).group()
Generating WSA download link: arch=x64 release_type=Retail
...
```

I'm not sure if these invalid sequences actually affect the result, but it's best to fix them anyway.