### PR TITLE
Fix root-sol none in the run.sh

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -86,6 +86,8 @@ if (YesNoBox '([title]="Root" [text]="Do you want to Root WSA?")'); then
             'kernelsu' "KernelSU" 'off'
     )
     COMMAND_LINE+=(--root-sol "$ROOT_SOL")
+else
+    COMMAND_LINE+=(--root-sol "none")
 fi
 
 if [ "$ROOT_SOL" = "magisk" ]; then


### PR DESCRIPTION
Fixed an issue where magisk was installed when selecting "No" in the "Do you want to Root WSA?" question.