### PR TITLE
Fixed selection without root in the run.sh

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -86,6 +86,8 @@ if (YesNoBox '([title]="Root" [text]="Do you want to Root WSA?")'); then
             'kernelsu' "KernelSU" 'off'
     )
     COMMAND_LINE+=(--root-sol "$ROOT_SOL")
+else
+    COMMAND_LINE+=(--root-sol "none")
 fi
 
 if [ "$ROOT_SOL" = "magisk" ]; then


### PR DESCRIPTION
Fixed an issue where magisk was installed when selecting No in the Do you want to Root WSA? question.

Why did you close this pull request? When selecting "No" the commands are as follows: `--root-sol magisk --magisk-ver stable`. As a result, "magisk" is installed even if it was chosen not to install root. Although these parameters are not written to the 'command line', they are set in `build.sh` as default, so you need to explicitly set `--root-sol none` in `run.sh` or edit the default options in `build.sh`